### PR TITLE
fix: store prefix in IconSetRegistration details (closes #20)

### DIFF
--- a/src/Registries/IconSetRegistration.php
+++ b/src/Registries/IconSetRegistration.php
@@ -55,7 +55,10 @@ class IconSetRegistration
             throw new InvalidArgumentException("Icon set path is not a valid directory: {$path}");
         }
 
-        $this->sets[$prefix] = ['path' => $path];
+        $this->sets[$prefix] = [
+            'path' => $path,
+            'prefix' => $prefix,
+        ];
 
         return $this;
     }

--- a/tests/Feature/EventDrivenRegistrationTest.php
+++ b/tests/Feature/EventDrivenRegistrationTest.php
@@ -1,6 +1,9 @@
 <?php
 
 use ArtisanPackUI\Icons\Registries\IconSetRegistration;
+use BladeUI\Icons\Factory;
+use BladeUI\Icons\IconsManifest;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
 
@@ -246,7 +249,34 @@ test('it preserves icon set metadata', function () {
 
     $sets = $filteredRegistry->getSets();
 
-    // The current implementation only stores path, not additional metadata
+    // Stored details must include both 'path' and 'prefix' so they can be
+    // handed directly to BladeUI\Icons\Factory::add() without throwing
+    // CannotRegisterIconSet::prefixNotDefined.
     expect($sets)->toHaveKey('meta')
-        ->and($sets['meta']['path'])->toBe(storage_path('test-event-icons-1'));
+        ->and($sets['meta']['path'])->toBe(storage_path('test-event-icons-1'))
+        ->and($sets['meta']['prefix'])->toBe('meta');
+});
+
+test('it stores the prefix in details so Factory::add does not throw prefixNotDefined', function () {
+    // Regression test for the bug fixed in this commit: previously addSet()
+    // stored only ['path' => ...], which caused BladeUI\Icons\Factory::add()
+    // to throw CannotRegisterIconSet::prefixNotDefined when the icons
+    // service provider tried to register an event-driven icon set.
+    $registry = new IconSetRegistration;
+    $registry->addSet(storage_path('test-event-icons-1'), 'regression');
+
+    $details = $registry->getSets()['regression'];
+
+    // Hand the details straight to a Factory the same way
+    // IconsServiceProvider::registerIconSets() does. This should not throw
+    // BladeUI\Icons\Exceptions\CannotRegisterIconSet::prefixNotDefined.
+    $filesystem = new Filesystem;
+    $factory = new Factory(
+        $filesystem,
+        new IconsManifest($filesystem, storage_path('test-event-icons-manifest.php'))
+    );
+    $factory->add('regression', $details);
+
+    expect($factory->all())->toHaveKey('regression')
+        ->and($factory->all()['regression']['prefix'])->toBe('regression');
 });

--- a/tests/Feature/IconRegistrationIntegrationTest.php
+++ b/tests/Feature/IconRegistrationIntegrationTest.php
@@ -349,7 +349,8 @@ test('it handles complex multi source registration scenario', function () {
 });
 
 test('it preserves additional icon set metadata', function () {
-    // Test basic icon set registration (current implementation only stores path)
+    // Verify event-driven registration stores both 'path' and 'prefix' in details
+    // so they can be consumed by BladeUI\Icons\Factory::add() directly.
     addFilter('ap.icons.register-icon-sets', function (IconSetRegistration $registry) {
         $registry->addSet(storage_path('integration-icons-third-party'), 'meta');
 
@@ -362,9 +363,10 @@ test('it preserves additional icon set metadata', function () {
 
     $metadataSet = $eventSets['meta'];
 
-    // Verify basic data is stored (current implementation only stores path)
     expect($metadataSet)->toHaveKey('path')
-        ->and($metadataSet['path'])->toBe(storage_path('integration-icons-third-party'));
+        ->toHaveKey('prefix')
+        ->and($metadataSet['path'])->toBe(storage_path('integration-icons-third-party'))
+        ->and($metadataSet['prefix'])->toBe('meta');
 
     // Verify directory exists
     expect(is_dir(storage_path('integration-icons-third-party')))->toBeTrue();


### PR DESCRIPTION
## Description

`IconSetRegistration::addSet()` was storing only `['path' => ...]` under each prefix key. `IconsServiceProvider::registerIconSets()` then passed those details straight to `BladeUI\Icons\Factory::add()`, which requires a `prefix` entry in its options array and throws `CannotRegisterIconSet::prefixNotDefined` when it is missing.

In any consumer app where an extension registers an icon set through the `ap.icons.register-icon-sets` filter (for example `artisanpack-ui/visual-editor` v1.1.0 alongside `owenvoke/blade-fontawesome`), every Blade render of an `<x-...>` component blew up with `prefixNotDefined`.

**Closes:** #20

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds new functionality)
- [ ] Enhancement (improves existing functionality)
- [ ] Refactoring (code improvement, no behavior change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Security fix
- [ ] Breaking change (breaks backward compatibility)

## Related Issue

**Issue:** #20

## Motivation and Context

Blocks downstream verification of `jmwd-keystone-cms`'s Laravel 13 upgrade — 609 of 618 Unit + Feature tests in that consumer app fail because every Blade render that touches an `<x-...>` component throws `BladeUI\Icons\Exceptions\CannotRegisterIconSet::prefixNotDefined`. Bug also reproduces on Laravel 12.

## Changes Made

- `src/Registries/IconSetRegistration.php`: `addSet()` now stores both `path` and `prefix` so the resulting details array is consumable by `BladeUI\Icons\Factory::add()` without further massaging.
- `tests/Feature/EventDrivenRegistrationTest.php`: updated the "preserves icon set metadata" test to assert the new `prefix` key, and added a regression test that hands the stored details to a real `BladeUI\Icons\Factory` to prove `prefixNotDefined` is no longer thrown.
- `tests/Feature/IconRegistrationIntegrationTest.php`: same metadata-test update.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.5.0)
- PHP Version: 8.4.3
- Project Version: release/2.1.2

**Tests Performed:**
1. Ran the package's Pest suite — 40 passed (105 assertions).
2. Added a regression test that wires the stored details into a real `BladeUI\Icons\Factory` and confirms `Factory::add()` does not throw.
3. Verified Pint runs clean against the modified files.

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** N/A — pure server-side registration fix; no UI surface changed.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:** New regression test `it stores the prefix in details so Factory::add does not throw prefixNotDefined` in `tests/Feature/EventDrivenRegistrationTest.php` constructs a real `BladeUI\Icons\Factory` and proves the details produced by `addSet()` can be registered without throwing.

## Documentation

- [ ] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** No public-API change — `addSet()` signature is unchanged; only the shape of internal stored details (`getSets()` return value) gained a `prefix` key alongside `path`.

## Screenshots

N/A.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted (Pint)
- [ ] Accessibility tests completed (N/A)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

## Out of Scope (per issue)

The issue notes a secondary collision when both `visual-editor` v1.1.0 and `owenvoke/blade-fontawesome` register the `fas`/`far`/`fab` prefixes. That contract decision (silent skip on collision vs. continue throwing) is left for a follow-up; this PR only addresses the primary `prefixNotDefined` regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved icon set registration to include complete metadata required for proper functionality. Icon sets now store both location path and prefix information, enabling better integration with icon-building components and ensuring all necessary metadata is available to consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->