### PR TITLE
Release v2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+## 2.1.2 - 2026-06-14
+
+### 🐛 Bug Fixes
+
+- **FIXED**: `IconSetRegistration::addSet()` now stores `prefix` alongside `path` in the resulting details array. Previously the stored details were `['path' => ...]` only, which caused `BladeUI\Icons\Factory::add()` to throw `CannotRegisterIconSet::prefixNotDefined` whenever an event-driven icon set was registered. This broke every Blade render of an `<x-...>` component in any consumer app that also had `owenvoke/blade-fontawesome` installed alongside an extension (e.g. `artisanpack-ui/visual-editor` v1.1.0) that uses the `ap.icons.register-icon-sets` filter hook. (#20, #21)
+
+### 🧪 Tests
+
+- **ADDED**: Regression test in `tests/Feature/EventDrivenRegistrationTest.php` that hands the stored details directly to a real `BladeUI\Icons\Factory` instance and asserts `Factory::add()` does not throw.
+- **UPDATED**: "Preserves icon set metadata" tests in `EventDrivenRegistrationTest` and `IconRegistrationIntegrationTest` to assert the new `prefix` key alongside `path`.
+
 ## 2.1.1 - 2026-06-09
 
 ### ✨ New Features

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "artisanpack-ui/icons",
   "description": "An extensibility layer for Blade Icons that enables flexible registration of custom SVG icon sets via config or events.",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "license": "MIT",
   "require": {
     "php": "^8.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cd4d77233e2b3dcb73fd519de35689af",
+    "content-hash": "e17abd0d39e2650feb3bc1d74ac9818f",
     "packages": [
         {
             "name": "artisanpack-ui/hooks",
@@ -10278,5 +10278,5 @@
         "php": "^8.2"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/src/Registries/IconSetRegistration.php
+++ b/src/Registries/IconSetRegistration.php
@@ -55,7 +55,10 @@ class IconSetRegistration
             throw new InvalidArgumentException("Icon set path is not a valid directory: {$path}");
         }
 
-        $this->sets[$prefix] = ['path' => $path];
+        $this->sets[$prefix] = [
+            'path' => $path,
+            'prefix' => $prefix,
+        ];
 
         return $this;
     }

--- a/tests/Feature/EventDrivenRegistrationTest.php
+++ b/tests/Feature/EventDrivenRegistrationTest.php
@@ -1,6 +1,9 @@
 <?php
 
 use ArtisanPackUI\Icons\Registries\IconSetRegistration;
+use BladeUI\Icons\Factory;
+use BladeUI\Icons\IconsManifest;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
 
@@ -246,7 +249,34 @@ test('it preserves icon set metadata', function () {
 
     $sets = $filteredRegistry->getSets();
 
-    // The current implementation only stores path, not additional metadata
+    // Stored details must include both 'path' and 'prefix' so they can be
+    // handed directly to BladeUI\Icons\Factory::add() without throwing
+    // CannotRegisterIconSet::prefixNotDefined.
     expect($sets)->toHaveKey('meta')
-        ->and($sets['meta']['path'])->toBe(storage_path('test-event-icons-1'));
+        ->and($sets['meta']['path'])->toBe(storage_path('test-event-icons-1'))
+        ->and($sets['meta']['prefix'])->toBe('meta');
+});
+
+test('it stores the prefix in details so Factory::add does not throw prefixNotDefined', function () {
+    // Regression test for the bug fixed in this commit: previously addSet()
+    // stored only ['path' => ...], which caused BladeUI\Icons\Factory::add()
+    // to throw CannotRegisterIconSet::prefixNotDefined when the icons
+    // service provider tried to register an event-driven icon set.
+    $registry = new IconSetRegistration;
+    $registry->addSet(storage_path('test-event-icons-1'), 'regression');
+
+    $details = $registry->getSets()['regression'];
+
+    // Hand the details straight to a Factory the same way
+    // IconsServiceProvider::registerIconSets() does. This should not throw
+    // BladeUI\Icons\Exceptions\CannotRegisterIconSet::prefixNotDefined.
+    $filesystem = new Filesystem;
+    $factory = new Factory(
+        $filesystem,
+        new IconsManifest($filesystem, storage_path('test-event-icons-manifest.php'))
+    );
+    $factory->add('regression', $details);
+
+    expect($factory->all())->toHaveKey('regression')
+        ->and($factory->all()['regression']['prefix'])->toBe('regression');
 });

--- a/tests/Feature/IconRegistrationIntegrationTest.php
+++ b/tests/Feature/IconRegistrationIntegrationTest.php
@@ -349,7 +349,8 @@ test('it handles complex multi source registration scenario', function () {
 });
 
 test('it preserves additional icon set metadata', function () {
-    // Test basic icon set registration (current implementation only stores path)
+    // Verify event-driven registration stores both 'path' and 'prefix' in details
+    // so they can be consumed by BladeUI\Icons\Factory::add() directly.
     addFilter('ap.icons.register-icon-sets', function (IconSetRegistration $registry) {
         $registry->addSet(storage_path('integration-icons-third-party'), 'meta');
 
@@ -362,9 +363,10 @@ test('it preserves additional icon set metadata', function () {
 
     $metadataSet = $eventSets['meta'];
 
-    // Verify basic data is stored (current implementation only stores path)
     expect($metadataSet)->toHaveKey('path')
-        ->and($metadataSet['path'])->toBe(storage_path('integration-icons-third-party'));
+        ->toHaveKey('prefix')
+        ->and($metadataSet['path'])->toBe(storage_path('integration-icons-third-party'))
+        ->and($metadataSet['prefix'])->toBe('meta');
 
     // Verify directory exists
     expect(is_dir(storage_path('integration-icons-third-party')))->toBeTrue();


### PR DESCRIPTION
## Release Information

- **Release Version:** v2.1.2
- **Release Date:** 2026-06-14
- **Release Type:** Patch
- **Release Branch:** `release/2.1.2`
- **Target Branch:** `main`

## Release Summary

Patch release that fixes a regression introduced in 2.1.1 (and earlier) where `IconSetRegistration::addSet()` stored only `['path' => ...]` in its details array. `IconsServiceProvider::registerIconSets()` then forwarded those details to `BladeUI\Icons\Factory::add()`, which requires a `prefix` entry and throws `CannotRegisterIconSet::prefixNotDefined` when one is missing.

In any consumer app where an extension registers an icon set through the `ap.icons.register-icon-sets` filter hook (for example `artisanpack-ui/visual-editor` v1.1.0 alongside `owenvoke/blade-fontawesome`), every Blade render of an `<x-...>` component blew up at boot. This release restores Blade rendering for those consumers — including unblocking downstream verification of `jmwd-keystone-cms` against Laravel 13.

## Changelog

### Added
- N/A

### Changed
- `IconSetRegistration::addSet()` now stores both `path` and `prefix` in the resulting details array so it can be consumed directly by `BladeUI\Icons\Factory::add()`. The public method signature is unchanged; only the internal shape returned by `getSets()` gained a `prefix` key alongside `path`.

### Deprecated
- N/A

### Removed
- N/A

### Fixed
- Fixed `BladeUI\Icons\Exceptions\CannotRegisterIconSet::prefixNotDefined` thrown on every Blade `<x-...>` render in consumer apps that use the `ap.icons.register-icon-sets` filter hook to register an icon set.

### Security
- N/A

## Issues and Pull Requests

**Issues Fixed:**
- Closes #20

**Related PRs:**
- #21 — fix: store prefix in IconSetRegistration details

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes documented below

The public `addSet()` signature is unchanged. Only the internal shape of `getSets()` return entries grew a new key — any consumer reading those entries continues to find `path` in the same place.

**Migration guide:** None required.

## Testing Checklist

- [x] All automated tests passing (40 tests, 105 assertions via Pest)
- [ ] Manual testing completed in consumer app (recommended: re-run `jmwd-keystone-cms` Laravel 13 upgrade test suite)
- [ ] Accessibility tests passing (N/A — server-side registration fix only)
- [ ] Performance tests passing (N/A)
- [x] Security scan completed (`composer audit` — 0 vulnerabilities)
- [ ] Tested in staging environment
- [ ] Database migrations tested (N/A — no migrations)

**Testing notes:** Added a regression test in `tests/Feature/EventDrivenRegistrationTest.php` that hands the stored details directly to a real `BladeUI\Icons\Factory` instance and asserts `Factory::add()` does not throw `prefixNotDefined`.

## Documentation Checklist

- [x] CHANGELOG updated (2.1.2 entry with today's date)
- [ ] README updated (not needed — no public API change)
- [ ] API documentation updated (not needed — `addSet()` signature unchanged; docs do not document the `getSets()` return shape)
- [ ] Migration guide written (N/A — no breaking changes)
- [x] Release notes written (this PR + CHANGELOG)
- [ ] Wiki updated (not needed)

## Pre-Release Checklist

- [x] Version number updated in all necessary files (`composer.json` 2.1.1 → 2.1.2; `CHANGELOG.md` Unreleased → 2.1.2)
- [ ] Git tag prepared: `v2.1.2` (post-merge)
- [x] Release branch created/updated: `release/2.1.2`
- [x] Dependencies updated and tested (`composer validate` clean; `composer.lock` synced)
- [ ] Build artifacts generated (N/A — pure PHP package)
- [ ] Deployment plan reviewed
- [ ] Rollback plan prepared
- [ ] Stakeholders notified

### Dependency Notes

`composer audit`: **0 vulnerabilities**.

`composer outdated --direct` reports the following dev-only major-version updates available — none are required for this patch release:

- `orchestra/testbench` 10.11.0 → 11.1.0
- `pestphp/pest` 3.8.6 → 4.7.3
- `pestphp/pest-plugin-laravel` 3.2.0 → 4.1.0
- `phpunit/phpunit` 11.5.50 → 13.2.0
- `squizlabs/php_codesniffer` 3.13.5 → 4.0.1

All are dev dependencies; runtime dependencies (`illuminate/support`, `blade-ui-kit/blade-icons`, `artisanpack-ui/hooks`) are unchanged.

## Deployment

**Deployment steps:**
1. Merge this PR into `main`
2. Tag `v2.1.2` on the merge commit
3. Packagist will auto-update from the GitHub webhook

**Rollback plan:**
1. Revert the merge commit on `main`
2. Delete the `v2.1.2` tag (consumers can pin to `2.1.1`, but that re-exposes the bug)

**Configuration changes:** None.

**Environment variables:** None.

## Post-Release Tasks

- [ ] Tag created: `v2.1.2`
- [ ] Release notes published (GitHub release from tag)
- [ ] Documentation deployed
- [ ] Announcement sent
- [ ] Monitoring verified
- [ ] Previous version support documented

## Notes

This patch is a prerequisite for `artisanpack-ui/visual-editor` to safely run on Laravel 13 in any consumer app that also ships `owenvoke/blade-fontawesome`. The collision case noted in #20 (between `visual-editor`'s `FontAwesomeFreeIconSets` and `blade-fontawesome`'s identical `fas`/`far`/`fab` prefixes) is intentionally **out of scope** for this release — it requires a contract decision (silent skip vs. continue throwing) that belongs in a follow-up.

---

**Release Manager:** @jmwd-developer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved missing-prefix errors during event-driven icon set registration by ensuring prefix information is properly stored alongside path details.

* **Tests**
  * Enhanced test coverage to verify correct prefix storage and prevent regression in icon set registration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->