### PR TITLE
refactor: rename ap.icons.register-icon-sets to ap.icons.registerIconSets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## 2.2.0
+
+### Changed
+
+- Renamed hook `ap.icons.register-icon-sets` → `ap.icons.registerIconSets` to align with cross-package hooks convention. Old name is registered as a deprecation alias — subscribers continue firing but emit an info-level log. Alias removal deferred to next major.
+- Bumped `artisanpack-ui/hooks` to `^1.3`.
+
 ## 2.1.2 - 2026-06-14
 
 ### 🐛 Bug Fixes

--- a/README.md
+++ b/README.md
@@ -102,11 +102,13 @@ Perfect for packages that want to register their own icon sets:
 use ArtisanPackUI\Icons\Registries\IconSetRegistration;
 
 // In a service provider or event listener
-addFilter('ap.icons.register-icon-sets', function (IconSetRegistration $registry) {
+addFilter('ap.icons.registerIconSets', function (IconSetRegistration $registry) {
     $registry->addSet(__DIR__ . '/../../resources/icons', 'mypackage');
     return $registry;
 });
 ```
+
+> **Note:** In v2.2.0 the hook was renamed from `ap.icons.register-icon-sets` to `ap.icons.registerIconSets` to align with the cross-package hooks naming convention. The old name is registered as a temporary deprecation alias — existing subscribers continue firing but emit an info-level deprecation log. The alias will be removed in the next major release.
 
 ## Documentation
 

--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,13 @@
 {
   "name": "artisanpack-ui/icons",
   "description": "An extensibility layer for Blade Icons that enables flexible registration of custom SVG icon sets via config or events.",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "license": "MIT",
   "require": {
     "php": "^8.2",
     "illuminate/support": "^12.0 || ^13.0",
     "blade-ui-kit/blade-icons": "^1.8",
-    "artisanpack-ui/hooks": "^1.0"
+    "artisanpack-ui/hooks": "^1.3"
   },
   "require-dev": {
     "orchestra/testbench": "^10.0 || ^11.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e17abd0d39e2650feb3bc1d74ac9818f",
+    "content-hash": "2b8ed06b3e9c889971669fdfee249375",
     "packages": [
         {
             "name": "artisanpack-ui/hooks",
-            "version": "1.2.1",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ArtisanPack-UI/hooks.git",
-                "reference": "7aed2c1a4b87039690671363ae75f125cee4d4f4"
+                "reference": "2834223f643ee5e12f93edc816a6d2dca66d09aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ArtisanPack-UI/hooks/zipball/7aed2c1a4b87039690671363ae75f125cee4d4f4",
-                "reference": "7aed2c1a4b87039690671363ae75f125cee4d4f4",
+                "url": "https://api.github.com/repos/ArtisanPack-UI/hooks/zipball/2834223f643ee5e12f93edc816a6d2dca66d09aa",
+                "reference": "2834223f643ee5e12f93edc816a6d2dca66d09aa",
                 "shasum": ""
             },
             "require": {
@@ -68,9 +68,9 @@
             "description": "WordPress-style actions and filters for Laravel, with Blade directives and helper functions.",
             "support": {
                 "issues": "https://github.com/ArtisanPack-UI/hooks/issues",
-                "source": "https://github.com/ArtisanPack-UI/hooks/tree/v1.2.1"
+                "source": "https://github.com/ArtisanPack-UI/hooks/tree/v1.3.0"
             },
-            "time": "2026-06-09T01:56:33+00:00"
+            "time": "2026-07-20T18:37:59+00:00"
         },
         {
             "name": "blade-ui-kit/blade-icons",

--- a/src/IconsServiceProvider.php
+++ b/src/IconsServiceProvider.php
@@ -13,6 +13,7 @@
 namespace ArtisanPackUI\Icons;
 
 use ArtisanPackUI\Icons\Registries\IconSetRegistration;
+use ArtisanPackUI\Icons\Support\HookAliases;
 use BladeUI\Icons\Factory;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\ServiceProvider;
@@ -51,6 +52,8 @@ class IconsServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        HookAliases::register();
+
         $this->mergeConfiguration();
 
         if ($this->app->runningInConsole()) {
@@ -83,7 +86,7 @@ class IconsServiceProvider extends ServiceProvider
      *
      * This method merges icon sets defined in the final `artisanpack.icons`
      * configuration with sets registered by third-party extensions via the
-     * 'ap.icons.register-icon-sets' filter hook.
+     * 'ap.icons.registerIconSets' filter hook.
      *
      * @since 2.0.0
      *
@@ -106,7 +109,7 @@ class IconsServiceProvider extends ServiceProvider
 
             // Get icon sets registered via events.
             $eventRegistry = new IconSetRegistration;
-            $eventRegistry = applyFilters('ap.icons.register-icon-sets', $eventRegistry);
+            $eventRegistry = applyFilters('ap.icons.registerIconSets', $eventRegistry);
             $eventSets = $eventRegistry->getSets();
 
             // Merge sets, with config taking precedence over events.

--- a/src/Registries/IconSetRegistration.php
+++ b/src/Registries/IconSetRegistration.php
@@ -4,7 +4,7 @@
  * Icon Set Registration handler.
  *
  * Provides a structured API for third-party extensions to register icon sets
- * via the 'ap.icons.register-icon-sets' filter hook.
+ * via the 'ap.icons.registerIconSets' filter hook.
  *
  * @link       https://gitlab.com/jacob-martella-web-design/artisanpack-ui/artisanpack-ui-icons
  * @since      2.0.0

--- a/src/Support/HookAliases.php
+++ b/src/Support/HookAliases.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Hook alias registrations for the Icons package.
+ *
+ * Registers backwards-compatibility aliases for hooks that have been renamed.
+ * Subscribers on the old name continue firing but emit an info-level
+ * deprecation log via `HookDeprecations`. Alias removal is deferred to the
+ * next major release.
+ *
+ * @link       https://gitlab.com/jacob-martella-web-design/artisanpack-ui/artisanpack-ui-icons
+ * @since      2.2.0
+ */
+
+namespace ArtisanPackUI\Icons\Support;
+
+/**
+ * Registers deprecated hook aliases for the Icons package.
+ *
+ * @since 2.2.0
+ */
+class HookAliases
+{
+    /**
+     * Register all deprecated hook aliases.
+     *
+     * @since 2.2.0
+     */
+    public static function register(): void
+    {
+        deprecateHook('ap.icons.register-icon-sets', 'ap.icons.registerIconSets');
+    }
+}

--- a/tests/Feature/HookAliasTest.php
+++ b/tests/Feature/HookAliasTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use ArtisanPackUI\Icons\Registries\IconSetRegistration;
+
+beforeEach(function () {
+    removeAllFilters('ap.icons.register-icon-sets');
+    removeAllFilters('ap.icons.registerIconSets');
+});
+
+afterEach(function () {
+    removeAllFilters('ap.icons.register-icon-sets');
+    removeAllFilters('ap.icons.registerIconSets');
+});
+
+test('listeners on the deprecated hook name fire when the new hook is applied', function () {
+    $called = false;
+
+    addFilter('ap.icons.register-icon-sets', function (IconSetRegistration $registry) use (&$called) {
+        $called = true;
+
+        return $registry;
+    });
+
+    $registry = new IconSetRegistration;
+    applyFilters('ap.icons.registerIconSets', $registry);
+
+    expect($called)->toBeTrue();
+});


### PR DESCRIPTION
## Description

Renames the hook `ap.icons.register-icon-sets` to `ap.icons.registerIconSets` to align with the cross-package hooks naming convention (`ap.{packageCamelCase}.{camelCaseSegment}`). Old name registered as a backwards-compat deprecation alias via `HookDeprecations` — existing subscribers continue firing (info-level log). Alias removal deferred to next major.

Note: this hook is intentionally shared with visual-editor which re-fires it; the visual-editor rename lands in Wave 3.

**Closes:** #23

## Type of Change

- [x] Refactoring (code improvement, no behavior change)
- [x] Breaking change (breaks backward compatibility) — mitigated by the deprecation alias

## Related Issue

**Issue:** #23

## Motivation and Context

Cross-package hooks standardization initiative (umbrella hooks#13, Wave 1). The kebab-case sub-segment \`register-icon-sets\` violates the new canonical convention.

## Changes Made

- Bumped \`artisanpack-ui/hooks\` requirement to \`^1.3\`
- Renamed fire site in \`src/IconsServiceProvider.php\` (\`applyFilters\` call around line 109)
- Added \`src/Support/HookAliases.php\` calling \`deprecateHook()\`
- Wired \`HookAliases::register()\` first thing in \`IconsServiceProvider::boot()\`
- Updated docblock reference in \`src/Registries/IconSetRegistration.php\`
- Added \`tests/Feature/HookAliasTest.php\`
- Updated README and CHANGELOG (2.2.0 entry)
- Bumped package version \`2.1.2\` → \`2.2.0\`

## How Has This Been Tested?

**Tests Performed:**
1. \`./vendor/bin/pest\` — 41 passed, 106 assertions
2. \`./vendor/bin/pint\` — clean; PHPCS clean on new code
3. Manual verification via \`/packages/hooks/wave-one-renames\` in the dev app

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

## Documentation

- [x] README updated (hook name + alias note)
- [x] CHANGELOG updated
- [ ] \`docs/guide/*.md\` and \`resources/boost/guidelines/core.blade.php\` still reference the old name — deferred to a follow-up sweep