### PR TITLE
Release 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,17 @@
 
 ## Unreleased
 
-## 2.2.0
+## 2.2.0 - 2026-07-21
 
 ### Changed
 
 - Renamed hook `ap.icons.register-icon-sets` → `ap.icons.registerIconSets` to align with cross-package hooks convention. Old name is registered as a deprecation alias — subscribers continue firing but emit an info-level log. Alias removal deferred to next major.
 - Bumped `artisanpack-ui/hooks` to `^1.3`.
+
+### Documentation
+
+- Updated Extension API, Architecture, and Service Provider guides to reference the new `ap.icons.registerIconSets` hook name with deprecation notes for the legacy alias.
+- Added v2.1 → v2.2 migration section covering the hook rename.
 
 ## 2.1.2 - 2026-06-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## 2.2.0
+
+### Changed
+
+- Renamed hook `ap.icons.register-icon-sets` → `ap.icons.registerIconSets` to align with cross-package hooks convention. Old name is registered as a deprecation alias — subscribers continue firing but emit an info-level log. Alias removal deferred to next major.
+- Bumped `artisanpack-ui/hooks` to `^1.3`.
+
 ## 2.1.2 - 2026-06-14
 
 ### 🐛 Bug Fixes

--- a/README.md
+++ b/README.md
@@ -102,11 +102,13 @@ Perfect for packages that want to register their own icon sets:
 use ArtisanPackUI\Icons\Registries\IconSetRegistration;
 
 // In a service provider or event listener
-addFilter('ap.icons.register-icon-sets', function (IconSetRegistration $registry) {
+addFilter('ap.icons.registerIconSets', function (IconSetRegistration $registry) {
     $registry->addSet(__DIR__ . '/../../resources/icons', 'mypackage');
     return $registry;
 });
 ```
+
+> **Note:** In v2.2.0 the hook was renamed from `ap.icons.register-icon-sets` to `ap.icons.registerIconSets` to align with the cross-package hooks naming convention. The old name is registered as a temporary deprecation alias — existing subscribers continue firing but emit an info-level deprecation log. The alias will be removed in the next major release.
 
 ## Documentation
 

--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,13 @@
 {
   "name": "artisanpack-ui/icons",
   "description": "An extensibility layer for Blade Icons that enables flexible registration of custom SVG icon sets via config or events.",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "license": "MIT",
   "require": {
     "php": "^8.2",
     "illuminate/support": "^12.0 || ^13.0",
     "blade-ui-kit/blade-icons": "^1.8",
-    "artisanpack-ui/hooks": "^1.0"
+    "artisanpack-ui/hooks": "^1.3"
   },
   "require-dev": {
     "orchestra/testbench": "^10.0 || ^11.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e17abd0d39e2650feb3bc1d74ac9818f",
+    "content-hash": "2b8ed06b3e9c889971669fdfee249375",
     "packages": [
         {
             "name": "artisanpack-ui/hooks",
-            "version": "1.2.1",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ArtisanPack-UI/hooks.git",
-                "reference": "7aed2c1a4b87039690671363ae75f125cee4d4f4"
+                "reference": "2834223f643ee5e12f93edc816a6d2dca66d09aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ArtisanPack-UI/hooks/zipball/7aed2c1a4b87039690671363ae75f125cee4d4f4",
-                "reference": "7aed2c1a4b87039690671363ae75f125cee4d4f4",
+                "url": "https://api.github.com/repos/ArtisanPack-UI/hooks/zipball/2834223f643ee5e12f93edc816a6d2dca66d09aa",
+                "reference": "2834223f643ee5e12f93edc816a6d2dca66d09aa",
                 "shasum": ""
             },
             "require": {
@@ -68,9 +68,9 @@
             "description": "WordPress-style actions and filters for Laravel, with Blade directives and helper functions.",
             "support": {
                 "issues": "https://github.com/ArtisanPack-UI/hooks/issues",
-                "source": "https://github.com/ArtisanPack-UI/hooks/tree/v1.2.1"
+                "source": "https://github.com/ArtisanPack-UI/hooks/tree/v1.3.0"
             },
-            "time": "2026-06-09T01:56:33+00:00"
+            "time": "2026-07-20T18:37:59+00:00"
         },
         {
             "name": "blade-ui-kit/blade-icons",

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -164,7 +164,7 @@ return [
 
 ```php
 // In a package service provider
-addFilter('ap.icons.register-icon-sets', function ($sets) {
+addFilter('ap.icons.registerIconSets', function ($sets) {
     $sets[] = new IconSetRegistration(
         path: __DIR__ . '/../../resources/icons',
         prefix: 'mypackage'
@@ -179,7 +179,7 @@ addFilter('ap.icons.register-icon-sets', function ($sets) {
 protected function collectIconSets(): array
 {
     // 1. Collect event-driven registrations
-    $eventSets = apply_filters('ap.icons.register-icon-sets', []);
+    $eventSets = apply_filters('ap.icons.registerIconSets', []);
     
     // 2. Get config-based registrations
     $configSets = config('artisanpack.icons.sets', []);
@@ -444,7 +444,7 @@ foreach (config('artisanpack.icons.sets') as $set) {
 
 ```php
 // Debug event-driven registration
-addFilter('ap.icons.register-icon-sets', function (IconSetRegistration $registry) {
+addFilter('ap.icons.registerIconSets', function (IconSetRegistration $registry) {
     $beforeCount = count($registry->getSets());
     \Log::debug('MyPackage registering icons', [
         'path' => __DIR__ . '/../../resources/icons',

--- a/docs/guide/extension-api.md
+++ b/docs/guide/extension-api.md
@@ -14,9 +14,11 @@ The ArtisanPack UI Icons package provides a dual registration system:
 
 The event-driven system is perfect for packages that want to bundle their own icon sets and register them automatically when installed.
 
-## The `ap.icons.register-icon-sets` Filter Hook
+## The `ap.icons.registerIconSets` Filter Hook
 
-The primary extension point is the `ap.icons.register-icon-sets` filter hook. This hook allows packages to register icon sets that will be merged with user-configured sets.
+The primary extension point is the `ap.icons.registerIconSets` filter hook. This hook allows packages to register icon sets that will be merged with user-configured sets.
+
+> **Note:** In v2.2.0 this hook was renamed from `ap.icons.register-icon-sets` to `ap.icons.registerIconSets` to align with the cross-package hooks naming convention. The old name is registered as a temporary deprecation alias — existing subscribers continue firing but emit an info-level deprecation log. The alias will be removed in the next major release. Update your `addFilter()` calls to use the new name.
 
 ### Basic Usage
 
@@ -24,7 +26,7 @@ The primary extension point is the `ap.icons.register-icon-sets` filter hook. Th
 use ArtisanPackUI\Icons\Registries\IconSetRegistration;
 
 // In your package's service provider boot() method
-addFilter('ap.icons.register-icon-sets', function (IconSetRegistration $registry) {
+addFilter('ap.icons.registerIconSets', function (IconSetRegistration $registry) {
     $registry->addSet(__DIR__ . '/../../resources/icons', 'mypackage');
     return $registry;
 });
@@ -97,7 +99,7 @@ class MyPackageServiceProvider extends ServiceProvider
     public function boot()
     {
         // Register your package's icon set
-        addFilter('ap.icons.register-icon-sets', function ($sets) {
+        addFilter('ap.icons.registerIconSets', function ($sets) {
             $sets[] = new IconSetRegistration(
                 path: __DIR__ . '/../../resources/icons',
                 prefix: 'mypackage'
@@ -116,7 +118,7 @@ For packages that provide multiple themed icon sets:
 ```php
 public function boot()
 {
-    addFilter('ap.icons.register-icon-sets', function (IconSetRegistration $registry) {
+    addFilter('ap.icons.registerIconSets', function (IconSetRegistration $registry) {
         // Register multiple themed icon sets
         $iconSets = [
             'admin' => __DIR__ . '/../../resources/icons/admin',
@@ -141,7 +143,7 @@ Register icon sets based on configuration or environment:
 ```php
 public function boot()
 {
-    addFilter('ap.icons.register-icon-sets', function ($sets) {
+    addFilter('ap.icons.registerIconSets', function ($sets) {
         // Only register if the package is configured to provide icons
         if (config('mypackage.provide_icons', true)) {
             $sets[] = new IconSetRegistration(
@@ -170,7 +172,7 @@ Handle different installation contexts:
 ```php
 public function boot()
 {
-    addFilter('ap.icons.register-icon-sets', function ($sets) {
+    addFilter('ap.icons.registerIconSets', function ($sets) {
         // Resolve path based on package installation location
         $iconPath = $this->resolveIconPath();
         
@@ -211,7 +213,7 @@ private function resolveIconPath(): ?string
 ```php
 public function boot()
 {
-    addFilter('ap.icons.register-icon-sets', function ($sets) {
+    addFilter('ap.icons.registerIconSets', function ($sets) {
         try {
             $iconPath = __DIR__ . '/../../resources/icons';
             
@@ -250,7 +252,7 @@ If registration order matters, you can use priority parameters:
 
 ```php
 // Register with high priority (early registration)
-addFilter('ap.icons.register-icon-sets', function ($sets) {
+addFilter('ap.icons.registerIconSets', function ($sets) {
     // Critical system icons registered first
     array_unshift($sets, new IconSetRegistration(
         path: __DIR__ . '/../../resources/icons/critical',
@@ -261,7 +263,7 @@ addFilter('ap.icons.register-icon-sets', function ($sets) {
 }, 5); // Lower number = higher priority
 
 // Register with normal priority
-addFilter('ap.icons.register-icon-sets', function ($sets) {
+addFilter('ap.icons.registerIconSets', function ($sets) {
     $sets[] = new IconSetRegistration(
         path: __DIR__ . '/../../resources/icons',
         prefix: 'mypackage'
@@ -299,7 +301,7 @@ $sets[] = new IconSetRegistration(
 #### Check for Existing Prefixes
 
 ```php
-addFilter('ap.icons.register-icon-sets', function ($sets) {
+addFilter('ap.icons.registerIconSets', function ($sets) {
     // Check if our preferred prefix is already in use
     $existingPrefixes = array_column($sets, 'prefix');
     
@@ -397,7 +399,7 @@ class IconRegistrationTest extends TestCase
     {
         // Simulate the filter hook
         $sets = [];
-        $sets = apply_filters('ap.icons.register-icon-sets', $sets);
+        $sets = apply_filters('ap.icons.registerIconSets', $sets);
         
         // Assert your package's icon set is registered
         $prefixes = array_column($sets, 'prefix');
@@ -465,7 +467,7 @@ public function test_package_icons_render_in_blade()
 Add debugging to your registration:
 
 ```php
-addFilter('ap.icons.register-icon-sets', function ($sets) {
+addFilter('ap.icons.registerIconSets', function ($sets) {
     if (app()->environment('local')) {
         \Log::debug('MyPackage registering icons', [
             'path' => __DIR__ . '/../../resources/icons',

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -4,6 +4,71 @@ title: Migration Guide
 
 # Migration Guide
 
+## v2.1 to v2.2
+
+The v2.2 release renames the extension-API filter hook to align with the cross-package hooks naming convention.
+
+### Overview of Changes
+
+- **Renamed**: `ap.icons.register-icon-sets` → `ap.icons.registerIconSets`
+- **Backward Compatible**: The old hook name is registered as a deprecation alias. Existing subscribers continue firing without changes, but each invocation emits an info-level deprecation log. The alias will be removed in the next major release.
+- **Bumped**: `artisanpack-ui/hooks` constraint to `^1.3`.
+
+### Migration Steps
+
+#### Step 1: Update Dependencies
+
+Update your `composer.json`:
+
+```json
+{
+    "require": {
+        "artisanpack-ui/icons": "^2.2"
+    }
+}
+```
+
+Run the update:
+```bash
+composer update artisanpack-ui/icons
+```
+
+#### Step 2: Update Filter Registrations
+
+Rename the hook string in any `addFilter()` / `applyFilters()` calls that target the icon-set registry:
+
+**Before (v2.1):**
+```php
+addFilter('ap.icons.register-icon-sets', function (IconSetRegistration $registry) {
+    $registry->addSet(__DIR__ . '/../../resources/icons', 'mypackage');
+    return $registry;
+});
+```
+
+**After (v2.2):**
+```php
+addFilter('ap.icons.registerIconSets', function (IconSetRegistration $registry) {
+    $registry->addSet(__DIR__ . '/../../resources/icons', 'mypackage');
+    return $registry;
+});
+```
+
+#### Step 3: Silence Deprecation Logs
+
+Once every subscriber has been updated to the new name, the info-level deprecation log entries will stop being emitted. Search your codebase for the legacy string to confirm you've caught them all:
+
+```bash
+grep -r 'ap.icons.register-icon-sets' .
+```
+
+### What Stays the Same
+
+- The `IconSetRegistration` API is unchanged.
+- Config-based icon-set registration is unchanged.
+- Blade component usage (`<x-icon-prefix-name />`) is unchanged.
+
+---
+
 ## v2.0 to v2.1
 
 This guide will help you migrate from v2.0 to v2.1. The v2.1 release migrates from the `tormjens/eventy` package to the new `artisanpack-ui/hooks` package for event/filter management.

--- a/docs/guide/service-provider.md
+++ b/docs/guide/service-provider.md
@@ -89,11 +89,11 @@ return [
 
 ### 2. Event-Driven Registration
 
-Icon sets registered by third-party packages via the `ap.icons.register-icon-sets` filter hook:
+Icon sets registered by third-party packages via the `ap.icons.registerIconSets` filter hook:
 
 ```php
 // In a package service provider
-addFilter('ap.icons.register-icon-sets', function ($sets) {
+addFilter('ap.icons.registerIconSets', function ($sets) {
     $sets[] = new IconSetRegistration(
         path: __DIR__ . '/../../resources/icons',
         prefix: 'mypackage'
@@ -114,7 +114,7 @@ protected function registerIconSets()
         $configSets = config('artisanpack.icons.sets', []);
         
         // 2. Get event-driven icon sets
-        $eventSets = apply_filters('ap.icons.register-icon-sets', []);
+        $eventSets = apply_filters('ap.icons.registerIconSets', []);
         
         // 3. Merge sets (config takes precedence)
         $allSets = array_merge($eventSets, $configSets);
@@ -198,7 +198,7 @@ The service provider enables seamless integration with third-party packages thro
 // In MyPackageServiceProvider
 public function boot()
 {
-    addFilter('ap.icons.register-icon-sets', function ($sets) {
+    addFilter('ap.icons.registerIconSets', function ($sets) {
         if ($this->shouldProvideIcons()) {
             $sets[] = [
                 'path' => __DIR__ . '/../../resources/icons',
@@ -245,7 +245,7 @@ Enable debugging in local development:
 ```php
 // In a service provider or AppServiceProvider
 if (app()->environment('local')) {
-    addFilter('ap.icons.register-icon-sets', function ($sets) {
+    addFilter('ap.icons.registerIconSets', function ($sets) {
         \Log::debug('Custom Icons: Event-driven sets', ['count' => count($sets)]);
         return $sets;
     });

--- a/src/IconsServiceProvider.php
+++ b/src/IconsServiceProvider.php
@@ -13,6 +13,7 @@
 namespace ArtisanPackUI\Icons;
 
 use ArtisanPackUI\Icons\Registries\IconSetRegistration;
+use ArtisanPackUI\Icons\Support\HookAliases;
 use BladeUI\Icons\Factory;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\ServiceProvider;
@@ -51,6 +52,8 @@ class IconsServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        HookAliases::register();
+
         $this->mergeConfiguration();
 
         if ($this->app->runningInConsole()) {
@@ -83,7 +86,7 @@ class IconsServiceProvider extends ServiceProvider
      *
      * This method merges icon sets defined in the final `artisanpack.icons`
      * configuration with sets registered by third-party extensions via the
-     * 'ap.icons.register-icon-sets' filter hook.
+     * 'ap.icons.registerIconSets' filter hook.
      *
      * @since 2.0.0
      *
@@ -106,7 +109,7 @@ class IconsServiceProvider extends ServiceProvider
 
             // Get icon sets registered via events.
             $eventRegistry = new IconSetRegistration;
-            $eventRegistry = applyFilters('ap.icons.register-icon-sets', $eventRegistry);
+            $eventRegistry = applyFilters('ap.icons.registerIconSets', $eventRegistry);
             $eventSets = $eventRegistry->getSets();
 
             // Merge sets, with config taking precedence over events.

--- a/src/Registries/IconSetRegistration.php
+++ b/src/Registries/IconSetRegistration.php
@@ -4,7 +4,7 @@
  * Icon Set Registration handler.
  *
  * Provides a structured API for third-party extensions to register icon sets
- * via the 'ap.icons.register-icon-sets' filter hook.
+ * via the 'ap.icons.registerIconSets' filter hook.
  *
  * @link       https://gitlab.com/jacob-martella-web-design/artisanpack-ui/artisanpack-ui-icons
  * @since      2.0.0

--- a/src/Registries/IconSetRegistration.php
+++ b/src/Registries/IconSetRegistration.php
@@ -56,7 +56,7 @@ class IconSetRegistration
         }
 
         $this->sets[$prefix] = [
-            'path' => $path,
+            'path'   => $path,
             'prefix' => $prefix,
         ];
 

--- a/src/Support/HookAliases.php
+++ b/src/Support/HookAliases.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Hook alias registrations for the Icons package.
+ *
+ * Registers backwards-compatibility aliases for hooks that have been renamed.
+ * Subscribers on the old name continue firing but emit an info-level
+ * deprecation log via `HookDeprecations`. Alias removal is deferred to the
+ * next major release.
+ *
+ * @link       https://gitlab.com/jacob-martella-web-design/artisanpack-ui/artisanpack-ui-icons
+ * @since      2.2.0
+ */
+
+namespace ArtisanPackUI\Icons\Support;
+
+/**
+ * Registers deprecated hook aliases for the Icons package.
+ *
+ * @since 2.2.0
+ */
+class HookAliases
+{
+    /**
+     * Register all deprecated hook aliases.
+     *
+     * @since 2.2.0
+     */
+    public static function register(): void
+    {
+        deprecateHook('ap.icons.register-icon-sets', 'ap.icons.registerIconSets');
+    }
+}

--- a/tests/Feature/HookAliasTest.php
+++ b/tests/Feature/HookAliasTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use ArtisanPackUI\Icons\Registries\IconSetRegistration;
+
+beforeEach(function () {
+    removeAllFilters('ap.icons.register-icon-sets');
+    removeAllFilters('ap.icons.registerIconSets');
+});
+
+afterEach(function () {
+    removeAllFilters('ap.icons.register-icon-sets');
+    removeAllFilters('ap.icons.registerIconSets');
+});
+
+test('listeners on the deprecated hook name fire when the new hook is applied', function () {
+    $called = false;
+
+    addFilter('ap.icons.register-icon-sets', function (IconSetRegistration $registry) use (&$called) {
+        $called = true;
+
+        return $registry;
+    });
+
+    $registry = new IconSetRegistration;
+    applyFilters('ap.icons.registerIconSets', $registry);
+
+    expect($called)->toBeTrue();
+});


### PR DESCRIPTION
## Release Information

- **Release Version:** v2.2.0
- **Release Date:** 2026-07-21
- **Release Type:** Minor
- **Release Branch:** `release/2.2`
- **Target Branch:** `main`

## Release Summary

Renames the extension-API filter hook to align with the cross-package hooks naming convention, with a temporary backward-compatibility alias so existing subscribers keep firing (with a deprecation log). Docs updated across the board.

## Changelog

### Changed
- Renamed hook `ap.icons.register-icon-sets` → `ap.icons.registerIconSets` to align with the cross-package hooks convention. The old name is registered as a deprecation alias — subscribers continue firing but emit an info-level log. Alias removal deferred to the next major.
- Bumped `artisanpack-ui/hooks` constraint to `^1.3`.

### Documentation
- Updated Extension API, Architecture, and Service Provider guides to reference `ap.icons.registerIconSets` with a deprecation note for the legacy alias.
- Added a v2.1 → v2.2 migration section covering the hook rename.

## Issues and Pull Requests

**Related PRs:**
- #24 (refactor/23-rename-register-icon-sets-hook)

## Breaking Changes

- [x] No breaking changes (legacy hook name preserved via deprecation alias)
- [ ] Breaking changes documented below

## Testing Checklist

- [x] All automated tests passing (41 passed / 106 assertions)
- [x] Security scan completed (9 medium-severity advisories in `guzzlehttp/guzzle` + `guzzlehttp/psr7` — both transitive dev-only deps via testbench; not shipped to consumers)
- [ ] Manual testing completed

## Documentation Checklist

- [x] CHANGELOG updated (2.2.0 stamped with 2026-07-21)
- [x] API documentation updated (`docs/guide/extension-api.md`, `architecture.md`, `service-provider.md`)
- [x] Migration guide written (`docs/guide/migration.md` — new v2.1 → v2.2 section)

## Pre-Release Checklist

- [x] Version number updated in all necessary files (composer.json = 2.2.0; `@since 2.2.0` tags in `src/Support/HookAliases.php`)
- [ ] Git tag prepared: `v2.2.0`
- [x] Release branch updated: `release/2.2`
- [x] Dependencies updated and tested (lock file in sync)

## Release Prep Summary

- Versions: composer.json already at 2.2.0; all `@since` tags consistent
- Dependencies: lock in sync; 0 outdated direct deps flagged; 9 medium-severity advisories on transitive dev-only Guzzle packages
- Lint: Pint passed; PHPCS fixed one adjacent-double-arrow alignment issue in `IconSetRegistration.php`
- Tests: 41 passed, 106 assertions, 0.43s
- Docs: replaced legacy hook name across 3 guides, added v2.1 → v2.2 migration section, stamped CHANGELOG
